### PR TITLE
Update Discord invitation link

### DIFF
--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -25,7 +25,7 @@ export default {
   methods: {
     openURL() {
       window.open(
-        "https://top.gg/bot/765063751208402944/invite",
+        "https://discord.com/oauth2/authorize?client_id=1410693429478031411&permissions=2147485696&integration_type=0&scope=bot+applications.commands",
         "_blank",
         "noopener"
       );


### PR DESCRIPTION
## Summary
- update Add to Discord button to use new OAuth invite URL

## Testing
- `npm test` (fails: Missing script: test)
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1900148188324a5b516d0c0ff1792